### PR TITLE
Include CraftFiles in Release & CKAN install

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -16,3 +16,4 @@ jobs:
     uses: KSPModdingLibs/KSPBuildTools/.github/workflows/build.yml@main
     with:
       solution-file-path: 'Source/BoringCrewServices.sln'
+      artifacts: GameData CraftFiles LICENSE* README* CHANGELOG*

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -13,3 +13,4 @@ jobs:
     with:
       solution-file-path: 'Source/BoringCrewServices.sln'
       version-string: ${{ inputs.version-string }}
+      artifacts: GameData CraftFiles LICENSE* README* CHANGELOG*

--- a/GameData/BoringCrewServices/BoringCrewServices.ckan
+++ b/GameData/BoringCrewServices/BoringCrewServices.ckan
@@ -7,6 +7,12 @@ author:
   - Zorg
   - DylanSemrau
   - SofieBrink
+install: 
+  - find: BoringCrewServices
+    install_to: GameData
+  - find: CraftFiles
+    install_to: Ships
+    as: VAB
 depends:
   - name: ModuleManager
   - name: B9PartSwitch


### PR DESCRIPTION
- Updated workflows to include the CraftFiles folder in the release zips.
- Updated internal .CKAN to install craft files