### PR TITLE
Pin KSPBT workflow versions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build:
-    uses: KSPModdingLibs/KSPBuildTools/.github/workflows/build.yml@main
+    uses: KSPModdingLibs/KSPBuildTools/.github/workflows/build.yml@0.0.4
     with:
       solution-file-path: 'Source/BoringCrewServices.sln'
       artifacts: GameData CraftFiles LICENSE* README* CHANGELOG*

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   create-release:
-    uses: KSPModdingLibs/KSPBuildTools/.github/workflows/create-release.yml@main
+    uses: KSPModdingLibs/KSPBuildTools/.github/workflows/create-release.yml@0.0.4
     with:
       solution-file-path: 'Source/BoringCrewServices.sln'
       version-string: ${{ inputs.version-string }}

--- a/.github/workflows/publish-to-spacedock.yml
+++ b/.github/workflows/publish-to-spacedock.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   publish-to-spacedock:
-    uses: KSPModdingLibs/KSPBuildTools/.github/workflows/publish-to-spacedock.yml@main
+    uses: KSPModdingLibs/KSPBuildTools/.github/workflows/publish-to-spacedock.yml@0.0.4
     with:
       spacedock-username: ${{ vars.SPACEDOCK_USERNAME }}
       mod-id: ${{ vars.SPACEDOCK_MOD_ID }}


### PR DESCRIPTION
pinning workflows to a branch instead of a tag can unexpectedly break in the future